### PR TITLE
 Bug 1290580 - Rebase docker infra off of CentOS 6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,23 +47,22 @@ RUN chown root.root /etc/sudoers && chmod 440 /etc/sudoers
 RUN su $BUGZILLA_USER -c "git clone $GITHUB_BASE_GIT -b $GITHUB_BASE_BRANCH $BUGZILLA_ROOT"
 
 # Copy setup and test scripts
-COPY *.sh generate_bmo_data.pl buildbot_step checksetup_answers.txt /
-RUN chmod 755 /*.sh /buildbot_step
+COPY *.sh generate_bmo_data.pl buildbot_step checksetup_answers.txt /docker/
+RUN chmod 755 /docker/*.sh /docker/buildbot_step
 
 # Bugzilla dependencies and setup
-RUN /bugzilla_config.sh
-RUN /my_config.sh
+RUN /docker/bugzilla_config.sh
+RUN /docker/my_config.sh
 
 # Final permissions fix
 RUN chown -R $BUGZILLA_USER.$BUGZILLA_USER $BUGZILLA_HOME
 
 # Testing scripts for CI
-ADD https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar /selenium-server.jar
+ADD https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar /docker/selenium-server.jar
 
 # Networking
 RUN echo "NETWORKING=yes" > /etc/sysconfig/network
 EXPOSE 80
-EXPOSE 22
 EXPOSE 5900
 
 # Supervisor

--- a/bugzilla.conf
+++ b/bugzilla.conf
@@ -1,5 +1,3 @@
-User bugzilla
-Group bugzilla
 ServerName localhost:80
 PerlSwitches -wT
 PerlConfigRequire /home/bugzilla/devel/htdocs/bmo/mod_perl.pl

--- a/bugzilla_config.sh
+++ b/bugzilla_config.sh
@@ -8,9 +8,9 @@ sleep 30
 mysql -u root mysql -e "GRANT ALL PRIVILEGES ON *.* TO bugs@localhost IDENTIFIED BY 'bugs'; FLUSH PRIVILEGES;" || exit 1
 mysql -u root mysql -e "CREATE DATABASE bugs CHARACTER SET = 'utf8';" || exit 1
 
-perl checksetup.pl /checksetup_answers.txt
-perl checksetup.pl /checksetup_answers.txt
-perl /generate_bmo_data.pl
+perl checksetup.pl /docker/checksetup_answers.txt
+perl checksetup.pl /docker/checksetup_answers.txt
+perl /docker/generate_bmo_data.pl
 
 perl -i -pe 's/^User apache/User bugzilla/' /etc/httpd/conf/httpd.conf
 perl -i -pe 's/^Group apache/Group bugzilla/' /etc/httpd/conf/httpd.conf


### PR DESCRIPTION
- nit: Move docker related scripts to /docker instead of in root dir
- nit: Use var for buildbot_step in runtests.sh
